### PR TITLE
Remove conditional check for 'experiment_project' in linker.py

### DIFF
--- a/linker.py
+++ b/linker.py
@@ -39,10 +39,6 @@ def create_symlinks(ref, api_key=None, dry_run=False):
     hrf = get_run(ref, api_key=api_key)
     for name, doc in hrf.documents():
         if name == "start":
-            if doc.get('experiment_project'):
-                # NOTE: shortcut for the workflow before data security; to be removed later
-                logger.info("Skipping the creation of the link because 'experiment_project' is set.")
-                return
             if detectors := doc.get("detectors"):
                 pass
             else:


### PR DESCRIPTION
This pull request makes a small change to the `create_symlinks` function in `linker.py`. The shortcut logic that skipped symlink creation when the `'experiment_project'` field was set has been removed. This means symlinks will now be created regardless of the presence of this field.

* Removed the conditional check that exited early if `'experiment_project'` was set in the `start` document, ensuring symlinks are always created.